### PR TITLE
update auto-bloodied-dead.js

### DIFF
--- a/module/hooks/auto-bloodied-dead.js
+++ b/module/hooks/auto-bloodied-dead.js
@@ -119,6 +119,8 @@ export async function setBloodiedDeadOnHPChange(actor, change, options, userId) 
     }
 
     async function deleteIfPresent(statusToCheck, actor) {
-        return actor.deleteEmbeddedDocuments("ActiveEffect", findEffectIds(statusToCheck, actor))
+        if (actor.statuses.has(statusToCheck) {
+            await actor.toggleStatusEffect(statusToCheck, { active: false })
+        }
     }
 }


### PR DESCRIPTION
Changed deleteIfPresent to toggle a status off rather than delete the active effect to accommodate a system change.

Context: Tracking bloodied is complicated if we want `@bloodied` to work in active effects and we’re handling it in part in actor.toggleStatusEffect; if a status is removed by having the AE deleted rather than using the toggle function, we’re going to miss that the status has been removed and, and any AEs that use `@bloodied` will be incorrect.

This is for V13, so nothing needs to be done until you’re fully ready to release for that Foundry version.