### PR TITLE
Added newer bonus key components for autocomplete

### DIFF
--- a/module/integrations/autocomplete-inline-properties.js
+++ b/module/integrations/autocomplete-inline-properties.js
@@ -38,14 +38,23 @@ function customGetter(sheet) {
 
     const powerEffectData = {}
 
-    const effectTypes = ["feat", "item", "power", "racial", "untyped"]
+    const bonusTypes = ["feat", "item", "power", "racial", "untyped"]
     const keywords = {
         power : [],
-        weapon: []
+        weapon: [],
+		effect: []
     }
 
-    Object.keys(game.dnd4e.config.effectTypes).forEach((key) => keywords.power.push(key))
-    Object.keys(game.dnd4e.config.powerSource).forEach((key) => keywords.power.push(key))
+    Object.keys(game.dnd4e.config.effectTypes).forEach((key) => {
+		keywords.power.push(key)
+		keywords.effect.push(key)
+	})
+	
+    Object.keys(game.dnd4e.config.powerSource).forEach((key) => {
+		keywords.power.push(key)
+		keywords.effect.push(key)
+	})
+	
     if (game.dnd4e.config.toolKeys) {
         Object.keys(game.dnd4e.config.toolKeys).forEach((key) => keywords.power.push(key))
         Object.keys(game.dnd4e.config.rangeKeys).forEach((key) => keywords.power.push(key))
@@ -66,17 +75,40 @@ function customGetter(sheet) {
     Object.keys(game.dnd4e.config.damageTypes).forEach((key) => {
         keywords.power.push(key)
         keywords.weapon.push(key)
+        keywords.effect.push(key)
     })
 
+    Object.keys(game.dnd4e.config.statusEffect).forEach((key) => {
+        keywords.effect.push(key)
+    })
+	
+	// Extra attributes unique to "power" fork
+    for(const prop of ["basic", "mBasic", "rBasic", "charge", "opp"]) {
+        keywords.power.push(prop)
+	}
+    for(const stat of ["Str", "Dex", "Con", "Int", "Wis", "Cha"]) {
+        keywords.power.push(`uses${stat}`)
+	}
+    for(const def of ["AC", "Fort", "Ref", "Wil"]) {
+        keywords.power.push(`vs${def}`)
+	}
+
     for(const powWep of ["power", "weapon"]) {
-        for (const attackDamage of ["attack", "damage"]) {
+        for (const attackDamage of ["attack", "damage", "defence"]) {
             for(const keyword of keywords[powWep]) {
-                for (const effectType of effectTypes) {
-                    createNestedObject(powerEffectData, [powWep,attackDamage,keyword,effectType], 0)
+                for (const bonusType of bonusTypes) {
+                    createNestedObject(powerEffectData, [powWep,attackDamage,keyword,bonusType], 0)
                 }
             }
         }
     }
+	for (const saveType of ["save", "saveDC"]) {
+		for(const keyword of keywords.effect) {
+			for (const bonusType of bonusTypes) {
+				createNestedObject(powerEffectData, ["effect",saveType,keyword,bonusType], 0)
+			}
+		}
+	}
 
     return {
         ...baseData,

--- a/module/integrations/autocomplete-inline-properties.js
+++ b/module/integrations/autocomplete-inline-properties.js
@@ -82,6 +82,11 @@ function customGetter(sheet) {
         keywords.effect.push(key)
     })
 	
+	// Extra attributes unique to "weapon" fork
+    for(const attr of ["proficient", "one", "spc"]) {
+        keywords.weapon.push(attr)
+	}
+	
 	// Extra attributes unique to "power" fork
     for(const prop of ["basic", "mBasic", "rBasic", "charge", "opp"]) {
         keywords.power.push(prop)


### PR DESCRIPTION
I noticed that many of the newer keys added to the system don't appear in autocomplete, so I took a shot at adding them. This should bring autocomplete to full parity with the current [system functionality](https://github.com/EndlesNights/dnd4eBeta/wiki/Active-Effects-and-Automation#user-content-Custom_4e_Modifiers).

- Adds the `defence` branch to the `power`/`weapon` root
- Adds the `effect` root with its `save`/`saveDC` branches
- Adds the system-defined status IDs as keys for `effect` branch
- Adds the special attributes for `power` (like `charge`) that are manually defined in the system
- Ditto special attributes for `weapon` (like `proficient`)

I've tried to match your code style and methodology, but please do review and edit to your standards!

I'm not sure if it's the most efficient way to add the special attributes (feels messy!) but if I'd used the system config for stuff like `uses[Abil]` and `vs[Def]` I would have had to sentence-case the keys somehow, and that seemed even messier >3>; I'm delighted if you have a better method! <XD